### PR TITLE
data.table Depends->Imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# artifacts from R CMD build/check
+*.Rcheck
+*.tar.gz
+

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,9 +5,10 @@ Version: 1.1.2
 Date: 2015-10-18
 Author: Erin LeDell, Maya Petersen, Mark van der Laan
 Maintainer: Erin LeDell <oss@ledell.org>
-Description: Tools for working with and evaluating cross-validated area under the ROC curve (AUC) estimators.  The primary functions of the package are ci.cvAUC and ci.pooled.cvAUC, which report cross-validated AUC and compute confidence intervals for cross-validated AUC estimates based on influence curves for i.i.d. and pooled repeated measures data, respectively.  One benefit to using influence curve based confidence intervals is that they require much less computation time than bootstrapping methods.  The utility functions, AUC and cvAUC, are simple wrappers for functions from the ROCR package. 
+Description: Tools for working with and evaluating cross-validated area under the ROC curve (AUC) estimators.  The primary functions of the package are ci.cvAUC and ci.pooled.cvAUC, which report cross-validated AUC and compute confidence intervals for cross-validated AUC estimates based on influence curves for i.i.d. and pooled repeated measures data, respectively.  One benefit to using influence curve based confidence intervals is that they require much less computation time than bootstrapping methods.  The utility functions, AUC and cvAUC, are simple wrappers for functions from the ROCR package.
 License: Apache License (== 2.0)
-Depends: ROCR, data.table
+Depends: ROCR
+Imports: data.table
 URL: https://github.com/ledell/cvAUC
 BugReports: https://github.com/ledell/cvAUC/issues
 LazyLoad: yes

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,5 +1,4 @@
 import(ROCR)
-import(data.table)
 importFrom("stats", "qnorm")
-
-exportPattern("^[^\\.]")
+importFrom("data.table", "data.table")
+exportPattern("^[^\\.:]")

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -4,3 +4,5 @@
   packageStartupMessage('Notice to cvAUC users: Major speed improvements in version 1.1.0')
   packageStartupMessage(' ')
 }
+
+`:=` = function(...) NULL


### PR DESCRIPTION
Thanks for using `data.table`! We noticed you are `Depend`ing on us and recently decided to strongly discourage downstream packages from doing so -- we think `Imports` is always better.

This PR attempts to make the migration from Depends to Imports for `data.table`.

If you have a strong reason for preferring `Depends`, we'd love to hear it over at our issue tracker:

https://github.com/Rdatatable/data.table/issues/3076