### PR TITLE
ci.cvAUC needs 0.5 for ties

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,14 +1,13 @@
 Package: cvAUC
 Type: Package
 Title: Cross-Validated Area Under the ROC Curve Confidence Intervals
-Version: 1.1.2
-Date: 2015-10-18
+Version: 1.1.3
+Date: 2021-04-26
 Author: Erin LeDell, Maya Petersen, Mark van der Laan
 Maintainer: Erin LeDell <oss@ledell.org>
 Description: Tools for working with and evaluating cross-validated area under the ROC curve (AUC) estimators.  The primary functions of the package are ci.cvAUC and ci.pooled.cvAUC, which report cross-validated AUC and compute confidence intervals for cross-validated AUC estimates based on influence curves for i.i.d. and pooled repeated measures data, respectively.  One benefit to using influence curve based confidence intervals is that they require much less computation time than bootstrapping methods.  The utility functions, AUC and cvAUC, are simple wrappers for functions from the ROCR package.
 License: Apache License (== 2.0)
-Depends: ROCR
-Imports: data.table
+Imports: ROCR, data.table
 URL: https://github.com/ledell/cvAUC
 BugReports: https://github.com/ledell/cvAUC/issues
 LazyLoad: yes

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,9 @@ To Do
 -----------------
 * Consider automatically converting `labels` or `predictions` to a vector if it's a 1-column data.frame.  Otherwise, it will fail the check that `length(unique(labels)) == 2` and `length(predictions) == length(labels)`.
 
+cvAUC 1.1.3 (2021-04-26)
+-----------------
+* `ci.cvAUC()` needs 0.5 for ties: https://github.com/ledell/cvAUC/issues/6
 
 cvAUC 1.1.2 (10-18-2015)
 -----------------

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,7 +1,6 @@
 .onAttach <- function(...) {
   packageStartupMessage(' ')
   packageStartupMessage('cvAUC version: ', utils::packageDescription('cvAUC')$Version)
-  packageStartupMessage('Notice to cvAUC users: Major speed improvements in version 1.1.0')
   packageStartupMessage(' ')
 }
 


### PR DESCRIPTION
Fixes https://github.com/ledell/cvAUC/issues/6 for `ci.cvAUC()`.  

TO DO:

- [ ] Add version for `ci.pooled.cvAUC()`.
- [ ] Benchmark new vs old version to see if the new code is scalable & fast (since we remove the `cumsum()`, not sure if the speeds will be different..).
- [ ] Send new version to CRAN.